### PR TITLE
Add more ergonomic connection methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `MagicBell.connect` and `MagicBell.disconnect` methods for more ergonomic connection management.
+
 ## [1.0.0] - 2022-07-05
 First open source release of the SDK.
 

--- a/magicbell/client.py
+++ b/magicbell/client.py
@@ -9,6 +9,7 @@ from .configuration import Configuration
 class MagicBell:
     """Central class for interacting with the MagicBell API.
     To be used as an asynchronous context manager.
+    If an asynchronous context manager isn't feasible, then the `connect` and `disconnect` methods can be used.  # noqa: E501
 
     Examples
     --------

--- a/magicbell/client.py
+++ b/magicbell/client.py
@@ -56,11 +56,25 @@ class MagicBell:
         self.channels = ChannelsAPI(self.http_client, self.configuration)
         self.graphql = GraphQLAPI(self.http_client, self.configuration)
 
-    async def __aenter__(self):
+    async def connect(self) -> None:
+        """Connect to the MagicBell API.
+
+        This method is called automatically when the async context is entered.
+        """
         if not self._is_unmanaged_http_client:
             await self.http_client.__aenter__()
+
+    async def disconnect(self, exc_type=None, exc_val=None, exc_tb=None) -> None:
+        """Disconnect from the MagicBell API.
+
+        This method is called automatically when the async context is exited.
+        """
+        if not self._is_unmanaged_http_client:
+            await self.http_client.__aexit__(exc_type, exc_val, exc_tb)
+
+    async def __aenter__(self):
+        await self.connect()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if not self._is_unmanaged_http_client:
-            await self.http_client.__aexit__(exc_type, exc_val, exc_tb)
+        await self.disconnect(exc_type, exc_val, exc_tb)


### PR DESCRIPTION
Some times an async context manager isn't feasible, so having explicit `connect` and `disconnect` methods are more ergonomic than `await mb.__aenter__()` or `await mb.__aexit__()`

```python
mb = MagicBell()
await mb.connect()
...
await mb.disconnect()
```