### PR TITLE
Fix noxfile default sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ import nox_poetry
 LINT_PATHS = ["magicbell", "noxfile.py", "tests"]
 
 nox.options.reuse_existing_virtualenv = True
-nox.options.sessions = ["lint", "tests"]
+nox.options.sessions = ["lint", "test"]
 
 
 @nox_poetry.session(python=["3.8", "3.9", "3.10"])


### PR DESCRIPTION
Running `nox` fails with:

```bash
$ nox
nox > Error while collecting sessions.
nox > Sessions not found: tests
```

`tests` needs to be `test`.