### PR TITLE
Fix setup-nox action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup nox
-        uses: excitedleigh/setup-nox@v2.1.0
+        uses: daisylb/setup-nox@v2.1.0
       - name: Setup poetry
         uses: Gr1N/setup-poetry@v7
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup nox
-        uses: excitedleigh/setup-nox@v2.1.0
+        uses: daisylb/setup-nox@v2.1.0
       - name: Setup poetry
         uses: Gr1N/setup-poetry@v7
       - name: Install dependencies


### PR DESCRIPTION
The username for `setup-nox` action was changed and broke the github actions, this updates the username to the correct name to avoid breaking.